### PR TITLE
Fix npm start

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ try {
     var pkg = path.join(process.cwd(), 'package.json');
     var data = fs.readFileSync(pkg).toString();
     data = JSON.parse(data);
-    data.scripts.start = 'budo --live index.js -- -t glslify';
+    data.scripts.start = 'budo index.js --live -- -t glslify';
     data = JSON.stringify(data, null, 2);
     fs.writeFileSync(pkg, data);
 } catch (e) {


### PR DESCRIPTION
On first run index.js wasn't being compiled or loaded, using the argument order specified in the current budo docs works.